### PR TITLE
Always memset structs with padding going in the message payload

### DIFF
--- a/pseudosql/src/rootsim_operations.c
+++ b/pseudosql/src/rootsim_operations.c
@@ -86,6 +86,7 @@ void CreateAndSendMessageFromGroupsList(lp_id_t sender_id, float priority, Group
 	}
 
 	Envelope e;
+	memset(&e, 0, sizeof(Envelope));
 	e.sender = sender_id;
 	e.priority = priority;
 
@@ -394,6 +395,7 @@ void DataIngestion(struct topology *topology, lp_id_t me, simtime_t now, DataSou
 	neighbors = GetAllNeighbors(topology, me, &num_neighbors);
 
 	Envelope e;
+	memset(&e, 0, sizeof(Envelope));
 	e.sender = me;
 	e.priority = 5.0f;
 


### PR DESCRIPTION
ROOT-Sim uses `memcmp` of message payloads for tie-breaking, so structs with padding that end up in the payload need to be `memset` for consistency.